### PR TITLE
Added automatic version upgrading

### DIFF
--- a/dist/buttonwood.protocol-list.json
+++ b/dist/buttonwood.protocol-list.json
@@ -1,6 +1,6 @@
 {
     "name": "Buttonwood",
-    "timestamp": "2022-11-28T15:57:57.650Z",
+    "timestamp": "2022-11-29T01:44:30.724Z",
     "version": {
         "major": 0,
         "minor": 0,

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "eslint:fix": "eslint . --fix --ext .ts,.tsx",
     "prettier": "prettier --config .prettierrc --write \"**/*.{js,json,md,sol,ts}\"",
     "prettier:list-different": "prettier --config .prettierrc --list-different \"**/*.{js,json,md,sol,ts}\"",
-    "start": "yarn build && node build/src/build.js",
+    "start": "yarn build && node build/src/build.js && yarn build",
     "test": "mocha -r ts-node/register 'test/**/*test.ts'"
   },
   "engines": {

--- a/src/build.ts
+++ b/src/build.ts
@@ -1,18 +1,36 @@
+import { Version } from '@uniswap/token-lists';
 import { writeFile } from 'fs/promises';
 import path from 'path';
+import { getNewVersion } from 'protocol-lists';
+import packageJson from '../package.json';
+import { getOldProtocolList } from './getOldProtocolList';
 import { getProtocolList } from './getProtocolList';
 import { getProtocols } from './getProtocols';
+
+async function updatePackageJsonVersion(version: Version) {
+  packageJson.version = `${version.major}.${version.minor}.${version.patch}`;
+  await writeFile('package.json', JSON.stringify(packageJson, null, 2), 'utf8');
+}
 
 async function build(): Promise<void> {
   const protocols = await getProtocols();
 
-  const protocolList = getProtocolList(
+  let protocolList = getProtocolList(
     {
       name: 'Buttonwood',
       keywords: ['buttonwood', 'defi'],
     },
     protocols,
   );
+
+  const newVersion = getNewVersion(
+    await getOldProtocolList(),
+    // stringify & parse to flush any undefined or null values that will be lost by the time the new list
+    //   has been written, but which cause unwanted diffs when calculating new version
+    JSON.parse(JSON.stringify(protocolList)),
+  );
+  await updatePackageJsonVersion(newVersion);
+  protocolList = { ...protocolList, version: newVersion };
 
   await writeFile(
     path.join('src', 'buttonwood.protocol-list.json'),

--- a/src/buttonwood.protocol-list.json
+++ b/src/buttonwood.protocol-list.json
@@ -1,6 +1,6 @@
 {
   "name": "Buttonwood",
-  "timestamp": "2022-11-28T15:59:17.889Z",
+  "timestamp": "2022-11-29T01:44:30.724Z",
   "version": {
     "major": 0,
     "minor": 0,

--- a/src/getFileFromGit.ts
+++ b/src/getFileFromGit.ts
@@ -1,0 +1,21 @@
+import child_process from 'child_process';
+
+export function getFileFromGit(
+  branch: string,
+  filepath: string,
+): Promise<string> {
+  return new Promise((res, rej) => {
+    child_process.exec(
+      `git show ${branch}:${filepath}`,
+      (err, stdout, stderr) => {
+        if (err) {
+          rej(err);
+        } else if (stderr) {
+          rej(stderr);
+        } else {
+          res(stdout);
+        }
+      },
+    );
+  });
+}

--- a/src/getOldProtocolList.ts
+++ b/src/getOldProtocolList.ts
@@ -1,0 +1,11 @@
+import { ProtocolList } from 'protocol-lists';
+import { getFileFromGit } from './getFileFromGit';
+
+export async function getOldProtocolList(): Promise<ProtocolList> {
+  const oldProtocolListText = await getFileFromGit(
+    'origin/main',
+    'src/buttonwood.protocol-list.json',
+  );
+  const oldProtocolList: ProtocolList = JSON.parse(oldProtocolListText);
+  return oldProtocolList;
+}

--- a/src/getProtocolList.ts
+++ b/src/getProtocolList.ts
@@ -1,5 +1,5 @@
-import { CommonListParams, getCommonList } from './getCommonList';
 import { ProtocolInfo, ProtocolList } from 'protocol-lists';
+import { CommonListParams, getCommonList } from './getCommonList';
 
 export function getProtocolList(
   commonParams: CommonListParams,

--- a/test/buttonwood.protocol-list.test.ts
+++ b/test/buttonwood.protocol-list.test.ts
@@ -2,9 +2,10 @@ import { getAddress } from '@ethersproject/address';
 import Ajv from 'ajv';
 import addFormats from 'ajv-formats';
 import { expect } from 'chai';
-import { schema } from 'protocol-lists';
+import { getNewVersion, schema } from 'protocol-lists';
 import packageJson from '../package.json';
 import { protocolList } from '../src';
+import { getOldProtocolList } from '../src/getOldProtocolList';
 import { pathExists } from '../src/utils/pathExists';
 import { getLocalPath } from './getLocalPath';
 
@@ -114,5 +115,15 @@ describe('buildList', () => {
     expect(packageJson.version).to.equal(
       `${protocolList.version.major}.${protocolList.version.minor}.${protocolList.version.patch}`,
     );
+  });
+
+  it('version is correctly upgraded', async () => {
+    const newVersion = getNewVersion(
+      await getOldProtocolList(),
+      // stringify & parse to flush any undefined or null values that will be lost by the time the new list
+      //   has been written, but which cause unwanted diffs when calculating new version
+      JSON.parse(JSON.stringify(protocolList)),
+    );
+    expect(protocolList.version).to.deep.equal(newVersion);
   });
 });


### PR DESCRIPTION
- yarn start now calls `yarn build` again after running to include any protocol list changes in the dist files
- added automatic version upgrading, where it checks the new list against the version at origin/main to determine how the version should be updated
- added unit test to check the version is correct